### PR TITLE
update-clerk-provider-signout

### DIFF
--- a/src/app/(public)/explore/page.tsx
+++ b/src/app/(public)/explore/page.tsx
@@ -1,4 +1,14 @@
 import Search from "@/components/flow-components/Search";
+import { Loader2 } from "lucide-react";
+import { Suspense } from "react";
+
+function SearchFallback() {
+  return (
+    <div className="w-full h-full flex justify-center items-center mt-8">
+      <Loader2 className="animate-spin w-8 h-8" />
+    </div>
+  );
+}
 
 export default function Explore() {
   return (
@@ -8,7 +18,9 @@ export default function Explore() {
           <h2 className="text-center text-lg font-semibold leading-8 text-gray-900">
             Explore Roadmaps
           </h2>
-          <Search />
+          <Suspense fallback={<SearchFallback />}>
+            <Search />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/src/components/app/appbar.tsx
+++ b/src/components/app/appbar.tsx
@@ -76,7 +76,7 @@ async function AppBar() {
           </div>
         </div>
         <span>
-          <UserButton afterSignOutUrl="/" />
+          <UserButton />
         </span>
       </div>
     </div>

--- a/src/components/app/providers.tsx
+++ b/src/components/app/providers.tsx
@@ -14,6 +14,7 @@ function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <ClerkProvider
+        afterSignOutUrl="/"
         appearance={{
           baseTheme: neobrutalism,
           variables: {

--- a/src/components/landing/roadmap-hero.tsx
+++ b/src/components/landing/roadmap-hero.tsx
@@ -23,7 +23,8 @@ async function RoadmapTicker() {
 }
 
 async function UserAvatars() {
-  const users = await (clerkClient as any).users.getUserList();
+  const client = await clerkClient();
+  const users = await client.users.getUserList();
   return (
     <>
       <div className="isolate flex -space-x-2 overflow-hidden">

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,8 @@ const isPublicRoute = createRouteMatcher([
   "/",
   "/explore",
   "/roadmap/(.*)",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
   "/api/health",
   "/api/webhook(.*)",
   "/api/og/(.*)",
@@ -13,15 +15,16 @@ const isPublicRoute = createRouteMatcher([
 ]);
 
 export default clerkMiddleware(async (auth, req) => {
-  if (!isPublicRoute(req)) await auth.protect();
+  if (!isPublicRoute(req)) {
+    await auth.protect();
+  }
 });
 
 export const config = {
   matcher: [
-    // Exclude files with a "." followed by an extension, which are typically static files.
-    // Exclude files in the _next directory, which are Next.js internals.
-    "/((?!.+\\.[\\w]+$|_next).*)",
-    // Re-include any files in the api or trpc folders that might have an extension
+    // Skip Next.js internals and all static files, unless found in search params
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    // Always run for API routes
     "/(api|trpc)(.*)",
   ],
 };


### PR DESCRIPTION
## Summary
- Update Clerk integration and sign-out handling across UI components.
- Wrap Search in Suspense with a loading fallback to show a spinner while loading.
- Expand public routes and tighten middleware matcher to avoid unnecessary middleware on static assets and include sign-in/sign-up as public.

Related Tickets / Documents
- Aligns components with Clerk's recommended usage and proxy.ts sign-out redirect pattern.

What changed
- Replace direct clerkClient property access with async clerkClient() calls.
- Remove afterSignOutUrl prop from UserButton; configure afterSignOutUrl centrally on ClerkProvider.
- Set UserButton to default configuration to match Clerk's current patterns.
- Add Suspense boundary and SearchFallback spinner around Search to improve perceived responsiveness.
- Add sign-in and sign-up to public routes.
- Tighten middleware matcher to skip Next.js internals and common static file extensions while always matching API and trpc routes.

Testing
- Confirm sign-out redirects use ClerkProvider afterSignOutUrl.
- Verify UserButton works with default config and no afterSignOutUrl prop.
- Ensure Search shows spinner during load.
- Confirm sign-in and sign-up pages are accessible without auth and static assets are not processed by middleware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicator on the explore page to improve user feedback during content loading.
  * Sign-in and sign-up routes are now publicly accessible without authentication barriers.

* **Bug Fixes**
  * Refined sign-out redirect behavior for improved navigation flow after logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->